### PR TITLE
fix yyloc in recent bison versions

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -104,7 +104,7 @@ constant : INTEGER
 variable : STRING
            {
 	       if (!driver.calc.existsVariable(*$1)) {
-		   error(yyloc, std::string("Unknown variable \"") + *$1 + "\"");
+		   error(yyla.location, std::string("Unknown variable \"") + *$1 + "\"");
 		   delete $1;
 		   YYERROR;
 	       }


### PR DESCRIPTION
Simple fix that makes it work with recent versions of bison which (after regenerating the shipped parser.cc file, ofcourse) somehow don't expose the old 'yyloc' anymore.
