### PR TITLE
remove `warning: deprecated directive` in bison 3.0.4

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -30,10 +30,10 @@
 %skeleton "lalr1.cc"
 
 /* namespace to enclose parser in */
-%name-prefix="example"
+%define api.namespace {example}
 
 /* set the parser's class identifier */
-%define "parser_class_name" "Parser"
+%define parser_class_name {Parser}
 
 /* keep track of the current position within the input */
 %locations


### PR DESCRIPTION
Trivial commit.
- `%name-prefix` has deprecated in bison 3.0.4. let’s use `%define api.namespace`.
- `%define "parser_class_name”` generates warning. it requires `{…}` values.
